### PR TITLE
send metadata on ping on c#

### DIFF
--- a/cpplib/src/client.cpp
+++ b/cpplib/src/client.cpp
@@ -71,14 +71,18 @@ bool Client::room_occupied(std::string metadata) {
   return this->update_status(ROOM_OCCUPIED, metadata);
 }
 
-bool Client::ping() {
+bool Client::ping(std::string metadata) {
+  if (metadata.empty()) {
+    metadata = "{}"
+  }
+
   //TODO what happens if the api is offline?
   try {
     std::string put_url = (boost::format("%s/scheduler/%s/rooms/%s/ping")
         % this->maestro_api_url % this->room_scheduler % this->room_id).str();
     long timestamp = unix_timestamp();
-    std::string putBody = (boost::format("{\"timestamp\": %ld, \"status\": \"%s\"}")
-        % timestamp % this->status).str();
+    std::string putBody = (boost::format("{\"timestamp\": %ld, \"status\": \"%s\", \"metadata\":%s}")
+        % timestamp % this->status % metadata).str();
     RestClient::Response r = RestClient::put(put_url, "application/json", putBody);
     auto res = json::parse(r.body);
     return res.at("success");
@@ -90,7 +94,7 @@ bool Client::ping() {
 
 void Client::ping_loop(){
   while (!this->stop_ping.load()) {
-    this->ping();
+    this->ping("");
     std::this_thread::sleep_for(std::chrono::seconds(this->ping_interval));
   }
 }

--- a/cpplib/src/client_wrapper.cpp
+++ b/cpplib/src/client_wrapper.cpp
@@ -46,7 +46,7 @@ extern "C" {
   }
 
   bool internal_ping(Client* obj){
-    return obj->ping();
+    return obj->ping("");
   }
 
   bool internal_room_ready(Client* obj) {
@@ -63,6 +63,10 @@ extern "C" {
 
   bool internal_room_terminating(Client* obj) {
     return obj->room_terminating("");
+  }
+
+  bool internal_ping_with_metadata(Client* obj, const char * metadata){
+    return obj->ping(metadata);
   }
 
   bool internal_room_ready_with_metadata(Client* obj, const char * metadata) {

--- a/maestro-unity/Maestro.cs
+++ b/maestro-unity/Maestro.cs
@@ -28,6 +28,7 @@ public class MaestroClient {
   private static IntPtr maestroClient = IntPtr.Zero;
   private static float PingInterval = 30;
   private static bool initialized = false;
+  private static string Metadata = "{}";
 
   private static void DebugWrapper(string log) {
 #if DEBUG
@@ -53,7 +54,7 @@ public class MaestroClient {
     }
   }
 
-  public static void Initialize(string apiUrl, string scheduler = null, string id = null, bool autoPing = true, float pingInterval = 30.0f, OnTerminating onTerminatingFunction = null) {
+  public static void Initialize(string apiUrl, string scheduler = null, string id = null, bool autoPing = true, float pingInterval = 30.0f, OnTerminating onTerminatingFunction = null, string metadata = "{}") {
     if (!initialized) {
       LinkDebugInternal (functionPointer);
       if (onTerminatingFunction != null) {
@@ -77,6 +78,7 @@ public class MaestroClient {
         Debug.LogError ("Maestro client failed to initialize 😿 : " + apiUrl);
       }
 
+      Metadata = metadata;
       AutoPingEnable = autoPing;
       PingInterval = pingInterval;
       var thread = new Thread(AutopingFunction);
@@ -97,7 +99,7 @@ public class MaestroClient {
 
   public static void Ping() {
     if (!IsInitialized) return;
-    PingInternal(maestroClient);
+    PingInternal(maestroClient, Metadata);
   }
 
   public static string PlayerEvent(Event playerEvent) {
@@ -205,6 +207,9 @@ public class MaestroClient {
 
   [DllImport("libmaestro", CallingConvention = CallingConvention.Cdecl, EntryPoint = "internal_ping")]
     private static extern bool PingInternal(IntPtr obj);
+
+  [DllImport("libmaestro", CallingConvention = CallingConvention.Cdecl, EntryPoint = "internal_ping_with_metadata")]
+    private static extern bool PingInternal(IntPtr obj, string metadata);
 
   [DllImport("libmaestro", CallingConvention = CallingConvention.Cdecl, EntryPoint = "internal_room_occupied")]
     private static extern bool RoomOccupiedInternal(IntPtr obj);


### PR DESCRIPTION
The idea is to send metadata also on ping (not only on update status). 

So receive it on the Initialize of Maestro.cs and send on ping loop. It is optional, then guarantees retro compatibility. 