### PR TITLE
adding MonoPInvokeCallback to make it compatible with IL2CPP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ venv
 .*swo
 *.swo
 
+# Node
+node_modules
+!maestro-node/Makefile
+
+# CMake
 CMakeCache.txt
 CMakeFiles
 CMakeScripts
@@ -61,5 +66,7 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
-node_modules
-!maestro-node/Makefile
+
+# C#
+.idea/
+*.user

--- a/maestro-unity/Maestro.cs
+++ b/maestro-unity/Maestro.cs
@@ -1,7 +1,8 @@
-﻿using UnityEngine;
-using System.Runtime.InteropServices;
-using System;
+﻿using System;
 using System.Threading;
+using System.Runtime.InteropServices;
+using UnityEngine;
+using AOT;
 
 public class MaestroClient {
   public static bool AutoPingEnable = true;
@@ -29,7 +30,9 @@ public class MaestroClient {
   private static float PingInterval = 30;
   private static bool initialized = false;
   private static string Metadata = "{}";
+  private delegate void DebugWrapperDelegate(string log);
 
+  [MonoPInvokeCallback(typeof(DebugWrapperDelegate))] 
   private static void DebugWrapper(string log) {
 #if DEBUG
     Debug.Log("Maestro:" + log);

--- a/maestro-unity/maestro-unity.nuspec
+++ b/maestro-unity/maestro-unity.nuspec
@@ -2,15 +2,15 @@
 <package>
   <metadata>
     <id>maestro_unity</id>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <authors>leonardohahn</authors>
     <owners>tfg</owners>
     <projectUrl>https://github.com/topfreegames/maestro-client</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>C# client for the maestro client</description>
-    <releaseNotes>Remove protobuf dependency</releaseNotes>
+    <releaseNotes>Add MonoPInvokeCallback to make Maestro compatible with IL2CPP</releaseNotes>
     <licenseUrl>https://github.com/topfreegames/maestro-client/blob/master/LICENSE</licenseUrl>
-    <copyright>Copyright (c) 2018 TFG Co</copyright>
+    <copyright>Copyright (c) 2022 TFG Co</copyright>
     <tags>maestro maestro-client</tags>
   </metadata>
   <files>


### PR DESCRIPTION
### What? 
Adding MonoPInvokeCallback attribute on maestro-unity to make it compatible with IL2CPP

### Why?
The use of the MonoPInvokeCallback attribute for cases where a managed delegate is marshaled to native code is required for IL2CPP